### PR TITLE
Fix desyncs due to CompCableConnection motes, fixes #447

### DIFF
--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -353,7 +353,8 @@ namespace Multiplayer.Client
                 var canEverSpectate = typeof(RitualRoleAssignments).GetMethod(nameof(RitualRoleAssignments.CanEverSpectate));
 
                 var effectMethods = new MethodBase[] { subSustainerStart, sampleCtor, subSoundPlay, effecterTick, effecterTrigger, effecterCleanup, randomBoltMesh, drawTrackerCtor, randomHair };
-                var moteMethods = typeof(MoteMaker).GetMethods(BindingFlags.Static | BindingFlags.Public);
+                var moteMethods = typeof(MoteMaker).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                    .Concat(typeof(CompCableConnection.Cable).GetMethod(nameof(CompCableConnection.Cable.Tick)));
                 var fleckMethods = typeof(FleckMaker).GetMethods(BindingFlags.Static | BindingFlags.Public)
                     .Where(m => m.ReturnType == typeof(void))
                     .Concat(typeof(FleckManager).GetMethods() // FleckStatic uses Rand in Setup method, FleckThrown uses RandomInRange in TimeInterval. May as well catch all in case mods do the same.


### PR DESCRIPTION
The method calls random whenever the mote is null or destroyed. There may be situations where the mote ends up being created late or destroyed for some players, but not the others. This is guaranteed to happen when playing with multiple maps, and seems like it may happen when the game is not paused when someone is joining.

Since the desync happens due to RNG call to randomize the mote position, this change should fix it by pushing/popping the RNG state before/after the method is called.