### PR TITLE
Fix/sync CompObelisk_Abductor (Warped Obelisk/Labyrinth)

### DIFF
--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -524,4 +524,11 @@ namespace Multiplayer.Client.Patches
         }
     }
 
+    [HarmonyPatch(typeof(CompObelisk_Abductor), nameof(CompObelisk_Abductor.GenerateLabyrinth))]
+    static class SynchronousAbductorObelisk
+    {
+        static void Prefix() => LongEventAlwaysSync.forceSynchronously = true;
+        static void Finalizer() => LongEventAlwaysSync.forceSynchronously = false;
+    }
+
 }


### PR DESCRIPTION
The obelisk currently causes desyncs due to the map being generated in a separate thread.

We currently make change asynchronous long events queued when executing synced commands into synchronous ones. To err on the side of caution, I've allowed this to be applied to any long event but only when a new field (`forceSynchronously`) is set to true.

I could make all long events (if MP is active) synchronous, rather than specific ones, if this is preferred.

Additional changes to `LongEventAlwaysSync` were also needed:
- Adding the `callback` action to `action` to be executed after, as `callback` is only executed on the main thread for asynchronous long events
- Adding `HarmonyPriority(Priority.HigherThanNormal)` to the patch, as this method needs to run before `SeedLongEvents` patch (to seed both action and callback)

The final change is to add prefix/finalizer to `CompObelisk_Abductor.GenerateLabyrinth` to set `forceSynchronously` to true/false. If we decide to make all long events in MP synchronous then this patch will be safe to remove.